### PR TITLE
Add support for building Mesos in Ubuntu Xenial Xerus (16.04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This program uses Docker via command line and it works perfectly fine with Docke
 - `Fedora 23`
 - `Ubuntu Precise`
 - `Ubuntu Trusty`
+- `Ubuntu Xenial`
 
 **More to come soon...**
 

--- a/docker/ubuntu:xenial/Dockerfile
+++ b/docker/ubuntu:xenial/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:xenial
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    autoconf \
+    automake \
+    build-essential \
+    git \
+    libapr1-dev libsvn-dev \
+    libcurl4-openssl-dev \
+    libsasl2-dev \
+    libsasl2-modules \
+    libtool \
+    maven \
+    openjdk-8-jdk \
+    python-boto \
+    python-dev \
+    python-software-properties \
+    software-properties-common \
+    ruby \
+    ruby-dev \
+    zlib1g \
+    zlib1g-dev \
+    zlibc \
+  && gem install fpm --no-ri --no-rdoc
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64


### PR DESCRIPTION
```
➜  mesos-toolbox git:(feature/support-ubuntu-xenial) ✗ ./mesos-toolbox.py build --mesos-version 0.28.0 --os ubuntu:xenial  
INFO:mesos-toolbox.py:Updating sources for https://github.com/apache/mesos.git...
INFO:mesos-toolbox.py:Done.
INFO:mesos-toolbox.py:Updating sources for https://github.com/mesosphere/mesos-deb-packaging.git...
INFO:mesos-toolbox.py:Done.
INFO:mesos-toolbox.py:Recording build process to /home/javier/.mesos/temp/0.28.0-ubuntu-xenial.1459771824.log.
INFO:mesos-toolbox.py:Fetching Mesos https://github.com/apache/mesos.git sources...
INFO:mesos-toolbox.py:No patches for mesos-deb-packaging b929d6b84bcc080b490a7ee79c0115e82984a648.
INFO:mesos-toolbox.py:Ensuring Mesos version 0.28.0...
INFO:mesos-toolbox.py:Checking for Docker image...
INFO:mesos-toolbox.py:Docker image not found. Building...
INFO:mesos-toolbox.py:Building Mesos 0.28.0 for ubuntu:xenial. This will take a while...
INFO:mesos-toolbox.py:Mesos 0.28.0 for ubuntu:xenial built successfully. Build took 1609 seconds. Output available in /home/javier/.mesos/packages/mesos/0.28.0-ubuntu-xenial. Cleaning up...
```

@radekg tested on a Linux host, if needed I can build it on a OSX machine as well.