### PR TITLE
Grep for complete word to check if image exists

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -156,7 +156,7 @@ class Utils(object):
     def is_docker_image(LOG, image_name):
         Utils.exit_if_docker_unavailable(LOG)
         LOG.info("Checking for Docker image...")
-        result = Utils.cmd("docker images | grep {}".format(image_name))
+        result = Utils.cmd("docker images | grep -w {}".format(image_name))
         return result['StdOut'] != ""
 
     @staticmethod


### PR DESCRIPTION
This vets off any doubts when checking image is available because if we have an image `mesos_release` and we want to see if `mesos` image is available, the above function will return true since `grep mesos` returns true even if image exists with name of `mesos_XXX` , but doesnt actually tell `mesos` named image exists.
correct way to check for image is be `grep` the complete name as a word using `-w` so `grep -w mesos` will only return true will image with sole name `mesos` exists.