### PR TITLE
Package haproxy-marathon-bridge. Silly error fix. Closes #40.

### DIFF
--- a/docker/marathon/default/data/marathon-build.sh
+++ b/docker/marathon/default/data/marathon-build.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
+set -e
+
 BUILD_DIR=/marathon-src
 PACKAGING_DIR=/tmp/marathon-packaging
 ASSEMBLY_WITH_TESTS=${ASSEMBLY_WITH_TESTS-false}
+INCLUDE_HAPROXY_MARATHON_BRIDGE=${INCLUDE_HAPROXY_MARATHON_BRIDGE-true}
 
 echo "Creating build directory..."
 
-cd ${BUILD_DIR}
+pushd ${BUILD_DIR} >/dev/null
 
 if [ $ASSEMBLY_WITH_TESTS = true ]; then
   echo "[MARATHON BUILD]: Assembling Marathon ${BUILD_MARATHON_VERSION} with tests..."
@@ -23,6 +26,15 @@ mkdir -p ${PACKAGING_DIR}${INSTALL_DIRECTORY}/target
 echo "[MARATHON BUILD]: Copying output..."
 cp -R bin ${PACKAGING_DIR}${INSTALL_DIRECTORY}
 cp -R target/scala-2* ${PACKAGING_DIR}${INSTALL_DIRECTORY}/target
+
+if [ $INCLUDE_HAPROXY_MARATHON_BRIDGE = true ]; then
+  echo "Including haproxy-marathon-bridge in this build..."
+  cp examples/haproxy-marathon-bridge ${PACKAGING_DIR}${INSTALL_DIRECTORY}/bin/
+  chmod +x ${PACKAGING_DIR}${INSTALL_DIRECTORY}/bin/haproxy-marathon-bridge
+fi
+
+popd >/dev/null
+
 # We do not package anything except marathon iteself.
 # Any service or config needs to be provided after installation.
 

--- a/lib/configs/marathon_config.py
+++ b/lib/configs/marathon_config.py
@@ -72,6 +72,10 @@ class MarathonConfig(object):
                                 dest="with_tests",
                                 help="Run unit tests when building Marathon.",
                                 action="store_true" )
+        Config.add_argument( "--no-haproxy-marathon-bridge",
+                                dest="no_haproxy_marathon_bridge",
+                                help="Do not package haproxy-marathon-bridge when packaging Marathon.",
+                                action="store_false" )
 
         return Config.ready(program)
 
@@ -129,6 +133,11 @@ class MarathonConfig(object):
     def with_tests():
         from lib.config import Config
         return "true" if Config.args().with_tests == True else "false"
+
+    @staticmethod
+    def no_haproxy_marathon_bridge():
+        from lib.config import Config
+        return "true" if Config.args().no_haproxy_marathon_bridge == True else "false"
 
     ##
     ## ADDITIONAL OPERATIONS:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -229,7 +229,7 @@ class Utils(object):
 
     @staticmethod
     def exit_if_docker_unavailable(LOG):
-        if not is_docker_available():
+        if not Utils.is_docker_available():
             Utils.print_result_error(LOG, "Not able to list Docker images. Is Docker installed and running?", result)
             exit(301)
 

--- a/marathon-toolbox.py
+++ b/marathon-toolbox.py
@@ -75,15 +75,18 @@ def op_build():
 
         LOG.info("Marathon version from SBT: {}".format( marathon_sbt_version ))
 
-        # TODO: Actual build
-        build_command = "docker run -ti -v {}:/output -v {}:/marathon-src -v {}:/root/.ivy2 -e \"BUILD_MARATHON_VERSION={}\" -e \"FPM_OUTPUT_VERSION={}\" -e \"ASSEMBLY_WITH_TESTS={}\" {} /bin/bash -c 'cd /marathon-build && ./marathon-build.sh; exit $?'".format(
-                                    os.path.dirname(packages_dir),
-                                    build_dir,
-                                    MarathonConfig.ivy2_dir(),
-                                    MarathonConfig.marathon_version(),
-                                    marathon_sbt_version,
-                                    MarathonConfig.with_tests(),
-                                    image_name )
+        docker_command = list()
+        docker_command.append("docker run -ti ")
+        docker_command.append("-v {}:/output ".format( os.path.dirname(packages_dir) ))
+        docker_command.append("-v {}:/marathon-src ".format( build_dir ))
+        docker_command.append("-v {}:/root/.ivy2 ".format( MarathonConfig.ivy2_dir() ))
+        docker_command.append("-e \"BUILD_MARATHON_VERSION={}\" ".format( MarathonConfig.marathon_version() ))
+        docker_command.append("-e \"FPM_OUTPUT_VERSION={}\" ".format( marathon_sbt_version ))
+        docker_command.append("-e \"ASSEMBLY_WITH_TESTS={}\" ".format( MarathonConfig.with_tests() ))
+        docker_command.append("-e \"INCLUDE_HAPROXY_MARATHON_BRIDGE={}\" ".format( MarathonConfig.no_haproxy_marathon_bridge() ))
+        docker_command.append("{} ".format( image_name ))
+        docker_command.append("/bin/bash -c 'cd /marathon-build && ./marathon-build.sh; exit $?'")
+        build_command = "".join( docker_command )
         
         Utils.cmd("echo '{}'".format(build_command.replace("'", "\\'")))
         LOG.info("Building Marathon {}. This will take a while...".format(MarathonConfig.marathon_version()))


### PR DESCRIPTION
Included by default. Use `--no-haproxy-marathon-bridge` to exclude.